### PR TITLE
Fix space in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 gem 'github-pages'
-gem 'jekyll paginate'
+gem 'jekyll-paginate'


### PR DESCRIPTION
To fix below error:

$ bundle exec jekyll build --safe

[!] There was an error parsing `Gemfile`: 'jekyll paginate' is not a valid gem name because it contains whitespace.. Bundler cannot continue.

 #  from /..../Gemfile:3
 #  -------------------------------------------
 #  gem 'github-pages'

>  gem 'jekyll paginate'
>  #  -------------------------------------------
