### PR TITLE
Fix url prefix for sharing popup css

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,7 @@
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/stylesheets/stylesheet.css">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-  <link rel="stylesheet" href="/stylesheets/sharing-popup.css">
+  <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/stylesheets/sharing-popup.css">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">


### PR DESCRIPTION
The url for the popover css file is not prefixed with the configured site url, so 404s when blogs are served with a root url defined.